### PR TITLE
Fix: Update PixiJS Graphics call for FAST enemy

### DIFF
--- a/entities.js
+++ b/entities.js
@@ -108,13 +108,13 @@ export class EntityManager {
 
         } else if (typeKey === 'FAST') {
             // Elongated diamond shape
-            enemyBody.path(
+            const points = [
                 0, -size,        // Top point
                 size * 0.6, 0,   // Right point
                 0, size,         // Bottom point
                 -size * 0.6, 0   // Left point
-            );
-            enemyBody.closePath();
+            ];
+            enemyBody.poly(points);
             enemyBody.fill(type.color);
             enemyBody.stroke({width: 1, color: 0xFFFFFF, alpha: 0.5});
         } else { // Default to circle if type not recognized


### PR DESCRIPTION
I changed `enemyBody.path()` to `enemyBody.poly()` in `entities.js` for the 'FAST' enemy type. This resolves a `TypeError: t.clone is not a function` error caused by changes in the PixiJS v8 Graphics API. The `poly()` method is the correct way to draw polygons from a list of points in PixiJS v8. I also removed a redundant `closePath()` call as `poly()` handles this by default.