### PR TITLE
Fix: Resolve TARGET_FPMS and null reference errors in game loop

### DIFF
--- a/entities.js
+++ b/entities.js
@@ -108,13 +108,13 @@ export class EntityManager {
 
         } else if (typeKey === 'FAST') {
             // Elongated diamond shape
-            enemyBody.path(
+            const points = [
                 0, -size,        // Top point
                 size * 0.6, 0,   // Right point
                 0, size,         // Bottom point
                 -size * 0.6, 0   // Left point
-            );
-            enemyBody.closePath();
+            ];
+            enemyBody.poly(points);
             enemyBody.fill(type.color);
             enemyBody.stroke({width: 1, color: 0xFFFFFF, alpha: 0.5});
         } else { // Default to circle if type not recognized

--- a/game.js
+++ b/game.js
@@ -544,7 +544,9 @@ class Game {
             
             for (let eIndex = gameState.enemies.length - 1; eIndex >= 0; eIndex--) {
                 const enemy = gameState.enemies[eIndex];
-                if (!enemy) continue; // Enemy might have been cleaned up
+                if (!bullet || !bullet.sprite || !enemy) {
+                    continue; // Skip this iteration if bullet, bullet.sprite, or enemy is null/undefined
+                }
 
                 const dx = bullet.sprite.x - enemy.x;
                 const dy = bullet.sprite.y - enemy.y;
@@ -578,7 +580,9 @@ class Game {
 
         // Player-enemy collisions
         gameState.enemies.forEach(enemy => {
-            if (!enemy || !gameState.player) return;
+            if (!enemy || !gameState.player) {
+                return; // Skip this iteration if enemy or player is null/undefined
+            }
             const dx = gameState.player.x - enemy.x;
             const dy = gameState.player.y - enemy.y;
             const dist = Math.sqrt(dx * dx + dy * dy);
@@ -956,7 +960,7 @@ class Game {
             // Dynamic color: Start bright yellow, fade to orange
             particle.initialColor = { r: 255, g: 255, b: 0 }; // Yellow
             particle.targetColor = { r: 255, g: 165, b: 0 }; // Orange
-            particle.fill(PIXI.utils.rgb2hex([particle.initialColor.r/255, particle.initialColor.g/255, particle.initialColor.b/255]));
+            particle.fill(PIXI.Color.shared.setValue([particle.initialColor.r/255, particle.initialColor.g/255, particle.initialColor.b/255]).toNumber());
             
             const angle = Math.random() * Math.PI * 2; // Random direction for more spread
             const speed = baseSpeed * (0.7 + Math.random() * 0.6); // Vary speed: 70% to 130% of base
@@ -977,7 +981,7 @@ class Game {
         }
         
         const animate = (ticker) => {
-            const deltaSeconds = ticker.deltaTime / PIXI.settings.TARGET_FPMS / 1000; // Correct delta in seconds
+            const deltaSeconds = ticker.deltaMS / 1000; // Correct delta in seconds
 
             for (let i = particles.length - 1; i >= 0; i--) {
                 const p = particles[i];
@@ -1006,7 +1010,7 @@ class Game {
                 } else {
                      p.rect(-p.geometry.width/2, -p.geometry.height/2, p.geometry.width, p.geometry.height);
                 }
-                p.fill(PIXI.utils.rgb2hex([r/255, g/255, b/255]));
+                p.fill(PIXI.Color.shared.setValue([r/255, g/255, b/255]).toNumber());
             }
             
             if (particles.length === 0) {
@@ -1033,7 +1037,7 @@ class Game {
         let flashAge = 0;
         const flashLifetime = 0.1; // seconds
         const flashTicker = (ticker) => {
-            const deltaSeconds = ticker.deltaTime / PIXI.settings.TARGET_FPMS / 1000;
+            const deltaSeconds = ticker.deltaMS / 1000;
             flashAge += deltaSeconds;
             if (flashAge >= flashLifetime) {
                 this.worldContainer.removeChild(flash);
@@ -1088,7 +1092,7 @@ class Game {
         }
         
         const animate = (ticker) => {
-            const deltaSeconds = ticker.deltaTime / PIXI.settings.TARGET_FPMS / 1000;
+            const deltaSeconds = ticker.deltaMS / 1000;
             for (let i = particles.length - 1; i >= 0; i--) {
                 const p = particles[i];
                 p.age += deltaSeconds;
@@ -1180,7 +1184,7 @@ class Game {
             // Correct way to get deltaMS in PixiJS v8 ticker is ticker.deltaMS or ticker.deltaTime (if you adjust for TARGET_FPMS)
             // Assuming ticker.deltaMS is available and provides milliseconds
             // If not, use ticker.deltaTime and convert: elapsed += (ticker.deltaTime / PIXI.settings.TARGET_FPMS) * 1000;
-             elapsed += ticker.deltaMS || (ticker.deltaTime / PIXI.Ticker.targetFPMS) * 1000;
+             elapsed += ticker.deltaMS;
 
 
             const progress = Math.min(elapsed / flashDuration, 1);


### PR DESCRIPTION
This commit addresses two issues:
1. TypeError related to PIXI.settings.TARGET_FPMS:
   - Updated calculations in `createHitEffect`, `createDeathEffect`, and `triggerDamageFlash` in `game.js` to use `ticker.deltaMS / 1000` for `deltaSeconds`, aligning with PixiJS v8 ticker properties.

2. TypeError: Cannot read properties of null (reading 'x'):
   - Added null checks for `bullet`, `bullet.sprite`, and `enemy` entities within the `checkCollisions` function in `game.js` before accessing their properties. This prevents errors when entities might have been destroyed or removed from lists prematurely.